### PR TITLE
Load cache: user_load php notice/failure to set cache when non-uid arrays are passed

### DIFF
--- a/modules/user/user.module
+++ b/modules/user/user.module
@@ -184,7 +184,7 @@ function user_load($array = array(), $reset = FALSE) {
 
   if ($return && $return->uid) {
     // Add the user to the static cache.
-    $user_cache[$array['uid']] = $return;
+    $user_cache[$return->uid] = $return;
   }
 
   return $return;


### PR DESCRIPTION
Fixing php notice that occurs when an array w/o uid is passed to user_load (the issue also caused the static cache to not be set).
