### PR TITLE
use drupal_static to static cache node_load() in a easier resetable way

### DIFF
--- a/modules/node/node.module
+++ b/modules/node/node.module
@@ -746,7 +746,7 @@ function node_load($param = array(), $revision = NULL, $reset = NULL) {
  *   A fully-populated node object.
  */
 function _node_load_direct($param = array(), $revision = NULL, $reset = NULL) {
-  static $nodes = array();
+  $nodes = &drupal_static('node_load', array());
 
   if ($reset) {
     $nodes = array();
@@ -820,6 +820,13 @@ function _node_load_direct($param = array(), $revision = NULL, $reset = NULL) {
   }
 
   return $node;
+}
+
+/**
+ * Resets the static cache of node_load().
+ */
+function node_load_reset() {
+  drupal_static_reset('node_load');
 }
 
 /**

--- a/modules/node_load_cache/node_load_cache.module
+++ b/modules/node_load_cache/node_load_cache.module
@@ -22,7 +22,7 @@
  */
 function node_load_cache_node_load_cache($param = array(), $revision = NULL, $reset = NULL) {
   global $user;
-  static $nodes = array();
+  $nodes = &drupal_static('node_load', array());
 
   $cacheable = ($revision == NULL && is_numeric($param)) ? "node/$param" : 0;
   if ($reset) {


### PR DESCRIPTION
Conflicts:
	modules/node/node.module